### PR TITLE
(Temp?) Workaround for Spaces in SSID

### DIFF
--- a/nmcli/data/device.py
+++ b/nmcli/data/device.py
@@ -55,7 +55,7 @@ class DeviceWifi:
     @classmethod
     def parse(cls, text: str) -> DeviceWifi:
         m = re.search(
-            r'^(\*|\s)\s+(\S*)\s+(\S*)\s+(\d+)\s+(\d+)\sMbit/s\s+(\d+)\s+\S+\s+(.*)$', text)
+            r'^(\*|\s)\s*(|\S*|\S+\s[\S]+|\S+\s[\S]+\s[\S]+)\s+(\S*)\s+(\d+)\s+(\d+)\sMbit/s\s+(\d+)\s+\S+\s+(.*)$', text)
         if m:
             in_use, ssid, mode, chan, rate, signal, security = m.groups()
             return DeviceWifi(in_use == '*', ssid, mode,

--- a/nmcli/data/device.py
+++ b/nmcli/data/device.py
@@ -55,7 +55,7 @@ class DeviceWifi:
     @classmethod
     def parse(cls, text: str) -> DeviceWifi:
         m = re.search(
-            r'^(\*|\s)\s*(|\S*|\S+\s[\S]+|\S+\s[\S]+\s[\S]+)\s+(\S*)\s+(\d+)\s+(\d+)\sMbit/s\s+(\d+)\s+\S+\s+(.*)$', text)
+            r'^(\*|\s)\s*(\S*|\S+\s[\S]+|\S+\s[\S]+\s[\S]+)\s+(\S*)\s+(\d+)\s+(\d+)\sMbit/s\s+(\d+)\s+\S+\s+(.*)$', text)
         if m:
             in_use, ssid, mode, chan, rate, signal, security = m.groups()
             return DeviceWifi(in_use == '*', ssid, mode,


### PR DESCRIPTION
Changed the Regex to have an or loop to handle up to 2 spaces in the middle of an SSID.

After fixing here's an example of the SSIDs it was able to process which has a mix of one spaces, two spaces and the original no spaces.

```SilverSurfers
SilverSurfers
Virgin Media
VM0140260
EE-6emkj2
ZyXEL6395ril
BT-PWA2M3
SKYE7DPE
BTWi-fi
VM5109126
VM8368544
VM6860915
5GHz-EE-6emkj2
Virgin Media
Virgin Media
FRITZ!Box 3490
Oguz's Wi-Fi Network
VM4084612
Virgin Media
Virgin Media
vodafone0905F3
FRITZ!Box 3490
vodafone0905F3
VM9774787
PLUSNET-QM9Q7X
FRITZ!Box 7530 YI
VM004367-2G
```

Fixes #24 , possibly only suitable as a temporary workaround.