### PR TITLE
Wifi name encode error

### DIFF
--- a/nmcli/_system.py
+++ b/nmcli/_system.py
@@ -35,7 +35,7 @@ class SystemCommand(SystemCommandInterface):
         commands = c + parameters
         try:
             r = self._run(commands, capture_output=True,
-                          check=True, env={'LANG': 'C'})
+                          check=True)
             return r.stdout.decode('utf-8')
         except CalledProcessError as e:
             rc = e.returncode


### PR DESCRIPTION
When I use the locale as "C" by setting the LANG environment variable, I can't properly encode some characters in the wifi name, so I can't connect to the wifi. But if I remove this parameter (env={'LANG': 'C'}) I can encode properly. Can you fixed this ?

for example;

my wifi name = "Cüneyt"

but my output = "C?neyt"