### PR TITLE
Add rescan parameter to nmcli device wifi

### DIFF
--- a/nmcli/_device.py
+++ b/nmcli/_device.py
@@ -145,11 +145,13 @@ class DeviceControl(DeviceControlInterface):
             wait) + ['device', 'delete', ifname]
         self._syscmd.nmcli(cmd)
 
-    def wifi(self, ifname: str = None) -> List[DeviceWifi]:
+    def wifi(self, ifname: str = None, rescan: bool = None) -> List[DeviceWifi]:
         cmd = ['-t', '-f', 'IN-USE,SSID,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,SECURITY',
                'device', 'wifi', 'list']
         if ifname is not None:
             cmd += ['ifname', ifname]
+        if rescan is not None:
+            cmd += ['--rescan', 'yes' if rescan else 'no']
         r = self._syscmd.nmcli(cmd)
         results = []
         rows = r.split('\n')


### PR DESCRIPTION
I used this in order to extract which wifi network was marked 'in use' without needing to perform a scan.

I had an additional use for instantly reporting results from whatever the previous scan must have been, and then running a rescan with delayed but more updated results.

`Usage: nmcli device wifi { ARGUMENTS | help }

Perform operation on Wi-Fi devices.

ARGUMENTS := [list [ifname <ifname>] [bssid <BSSID>] [--rescan yes|no|auto]]

List available Wi-Fi access points. The 'ifname' and 'bssid' options can be
used to list APs for a particular interface, or with a specific BSSID. The
--rescan flag tells whether a new Wi-Fi scan should be triggered.`