### PR TITLE
Adapting Wifi parsing for different nmcli versions

### DIFF
--- a/nmcli/data/device.py
+++ b/nmcli/data/device.py
@@ -64,7 +64,7 @@ class DeviceWifi:
         t = text.replace("\\:", "\uFFFE").replace(
             ":", "\uFFFF").replace("\uFFFE", ":")
         m = re.search(
-            r'^(\*|\s)\uFFFF(.*)\uFFFF(.*)\uFFFF(.*)\uFFFF(\d+)\uFFFF(\d+)\sMHz\uFFFF(\d+)\sMbit\/s\uFFFF(\d+)\uFFFF(.*)$', t)
+            r'^(\*|\s)\uFFFF(.*)\uFFFF(.*)\uFFFF(.*)\uFFFF(\d+)\uFFFF(\d+)\sMHz\uFFFF(\d+)\s(?:Mb|Mbit)\/s\uFFFF(\d+)\uFFFF(.*)$', t)
         if m:
             in_use, ssid, bssid, mode, chan, freq, rate, signal, security = m.groups()
             return DeviceWifi(in_use == '*', ssid, bssid, mode,


### PR DESCRIPTION
Hi!

I discovered your library to use nmcli through Python and it was great because it cuts me some work.
I decided to test it on my brand new Raspberry Pi 5 (nmcli version 1.42.4) to scan for wifi networks and print the result. Nothing exceptional.


```python
import nmcli

print(nmcli.device.wifi())
```

And then I got an error:

```python
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.11/dist-packages/nmcli/_device.py", line 160, in wifi
    results.append(DeviceWifi.parse(row))
                   ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/nmcli/data/device.py", line 72, in parse
    raise ValueError(f'Parse failed [{text}]')
ValueError: Parse failed [ :Freebox-XXXXXX:AA\:BB\:CC\:DD\:EE\:FF:Infra:11:2462 MHz:260 Mb/s:100:WPA2]
```

I decided to take a look at your `device.py` file and was surprised that you took the '\\:' problem the same way I just did 5 minutes before. After some trials and error, I finally spotted what was wrong. And it was just in front of my eyes.

By looking again at the error message, I saw `260 Mb/s`, but your regex is : 
```regex
... (\d+)\sMbit\/s ...
```

So here is the fix in the PR : 

```regex
... (\d+)\s(?:Mb|Mbit)\/s ...
```

Thanks again for your work