### PR TITLE
 updated regex for `nmcli general status` for nmcli version 1.48.6-1

### DIFF
--- a/nmcli/data/general.py
+++ b/nmcli/data/general.py
@@ -27,10 +27,11 @@ class General:
 
     @classmethod
     def parse(cls, text: str) -> General:
-        m = re.search(
-            r'^([\S\s]+)\s{2}(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s*', text)
+        #pattern = r'^([\S\s]+)\s{2}(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s*'
+        pattern = r'(.+?)\s+(.+?)\s+(.+?)\s+(.+?)\s+(.+?)\s+(.+?)\s+(.+)'
+        m = re.search(pattern, text)
         if m:
-            state, connectivity, wifi_hw, wifi, wwan_hw, wwan = m.groups()
+            state, connectivity, wifi_hw, wifi, wwan_hw, wwan, _metered = m.groups()
             return General(NetworkManagerState(state),
                            NetworkConnectivity(connectivity),
                            wifi_hw == 'enabled',


### PR DESCRIPTION
the newest version of nmcli has a new column we dont use named "metered"