### PR TITLE
Improvement on PR #70. Added `d8` test case to test_parse() in test_general. all tests pass

### DIFF
--- a/nmcli/data/general.py
+++ b/nmcli/data/general.py
@@ -27,10 +27,11 @@ class General:
 
     @classmethod
     def parse(cls, text: str) -> General:
-        m = re.search(
-            r'^([\S\s]+)\s{2}(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s*', text)
+        #pattern = r'^([\S\s]+)\s{2}(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s*'
+        pattern = r'(.+?)\s+(.+?)\s+(.+?)\s+(.+?)\s+(.+?)\s+(.+?)\s+(.+)'
+        m = re.search(pattern, text)
         if m:
-            state, connectivity, wifi_hw, wifi, wwan_hw, wwan = m.groups()
+            state, connectivity, wifi_hw, wifi, wwan_hw, wwan, _metered = m.groups()
             return General(NetworkManagerState(state),
                            NetworkConnectivity(connectivity),
                            wifi_hw == 'enabled',

--- a/nmcli/data/general.py
+++ b/nmcli/data/general.py
@@ -25,11 +25,49 @@ class General:
             'wwan': self.wwan
         }
 
+# case 1:
+# STATE      CONNECTIVITY  WIFI-HW  WIFI     WWAN-HW  WWAN     METERED
+# connected  full          enabled  enabled  missing  enabled  no (guessed)
+#
+# case 2:
+# unknown  none          enabled  enabled  enabled  disabled
+#
+# case 3:
+# connected (local only)  full          disabled  enabled  enabled  enabled
+#
+# see: https://regex101.com/r/zW1hHE/1
+
     @classmethod
     def parse(cls, text: str) -> General:
         #pattern = r'^([\S\s]+)\s{2}(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s*'
-        pattern = r'(.+?)\s+(.+?)\s+(.+?)\s+(.+?)\s+(.+?)\s+(.+?)\s+(.+)'
+
+        state_r = r'(?P<state>.+)'
+        connectivity_r = r'(?P<connectivity>\S+)'
+        wifi_hw_r = r'(?P<wifi_hw>\S+)'
+        wifi_r = r'(?P<wifi>\S+)'
+        wwan_hw_r = r'(?P<wwan_hw>\S+)'
+        wwan_r = r'(?P<wwan>\S+)'
+        metered_r = r'(?:  (?P<metered>.+)?)?'
+
+        pattern = (
+	        r'^'
+	        + state_r
+	        + r'  '
+	        + connectivity_r
+	        + r'\s+'
+	        + wifi_hw_r
+	        + r'  '
+	        + wifi_r
+	        + r'  '
+	        + wwan_hw_r
+	        + r'  '
+	        + wwan_r
+	        + metered_r
+	        + r'$'
+        )
+
         m = re.search(pattern, text)
+
         if m:
             state, connectivity, wifi_hw, wifi, wwan_hw, wwan, _metered = m.groups()
             return General(NetworkManagerState(state),

--- a/tests/data/test_general.py
+++ b/tests/data/test_general.py
@@ -58,6 +58,11 @@ def test_parse():
                                         NetworkConnectivity.FULL,
                                         True, True, True, True)
 
+    d8 = 'connected  full          enabled  enabled  missing  enabled  no (guessed)'
+    assert General.parse(d8) == General(NetworkManagerState.CONNECTED_GLOBAL,
+                                        NetworkConnectivity.FULL,
+                                        True, True, False, True)
+
 
 def test_parse_when_failed():
     with pytest.raises(ValueError) as e:


### PR DESCRIPTION
Dear ushiboy,

I've improved on my previous lacklustre effort in PR #70.
I've added a test to reflect the behaviour change in nmcli versions 1.48.x, see the added variable `d8` in test_parse().
All 156 regression test cases pass.

Sincerely, Khalil (kha-faz).