### PR TITLE
Added support for showing secrets in connection.show.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ nmcli.connection.down(name: str, wait: int = None) -> None
 Show details for specified connections.
 
 ```
-nmcli.connection.show(name: str) -> ConnectionDetails
+nmcli.connection.show(name: str, show_secrets: bool = False) -> ConnectionDetails
 ```
 
 #### nmcli.connection.reload

--- a/nmcli/_connection.py
+++ b/nmcli/_connection.py
@@ -88,8 +88,11 @@ class ConnectionControl(ConnectionControlInterface):
             wait) + ['connection', 'down', name]
         self._syscmd.nmcli(cmd)
 
-    def show(self, name: str) -> ConnectionDetails:
-        r = self._syscmd.nmcli(['connection', 'show', name])
+    def show(self, name: str, show_secrets: bool = False) -> ConnectionDetails:
+        cmd = ['connection', 'show', name]
+        if show_secrets:
+            cmd += ["--show-secrets"]
+        r = self._syscmd.nmcli(cmd)
         results = {}
         for row in r.split('\n'):
             m = re.search(r'^(\S+):\s*([\S\s]+)\s*', row)


### PR DESCRIPTION
Currently there's no way to get any connection secrets, because the `--show-secrets` command line switch for nmcli is missing. A single example:
`'802-11-wireless-security.psk': '<hidden>',`

After fix using `nmcli.connection.show("connection name", show_secrets=True)`:
`'802-11-wireless-security.psk': 'xxxxxxxx',`

There aren't any adverse effects to calling this with a connection that doesn't have secrets.

Also, thanks for this library. Appreciate it.

