### PR TITLE
feature: allow DeviceControl.wifi_connect to accept None as password

### DIFF
--- a/nmcli/_device.py
+++ b/nmcli/_device.py
@@ -182,11 +182,13 @@ class DeviceControl(DeviceControlInterface):
 
     def wifi_connect(self,
                      ssid: str,
-                     password: str,
+                     password: str | None,
                      ifname: str = None,
                      wait: int = None) -> None:
         cmd = add_wait_option_if_needed(
-            wait) + ['device', 'wifi', 'connect', ssid, 'password', password]
+            wait) + ['device', 'wifi', 'connect', ssid]
+        if password is not None:
+            cmd += ['password', password] 
         if ifname is not None:
             cmd += ['ifname', ifname]
         r = self._syscmd.nmcli(cmd)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -309,6 +309,24 @@ def test_wifi_connect():
         '--wait', '10', 'device', 'wifi', 'connect', ssid, 'password', password]
 
 
+def test_wifi_connect_without_password():
+    s = DummySystemCommand()
+    device = DeviceControl(s)
+    ssid = 'Open AP'
+    ifname = 'wlan0'
+
+    device.wifi_connect(ssid, None)
+    assert s.passed_parameters == ['device', 'wifi', 'connect', ssid]
+
+    device.wifi_connect(ssid, None, ifname)
+    assert s.passed_parameters == [
+        'device', 'wifi', 'connect', ssid, 'ifname', ifname]
+
+    device.wifi_connect(ssid, None, wait=10)
+    assert s.passed_parameters == [
+        '--wait', '10', 'device', 'wifi', 'connect', ssid]
+
+
 def test_wifi_connect_when_connection_activate_failed():
     s = DummySystemCommand(
         '''Error: Connection activation failed: (7) Secrets were required, but not provided.


### PR DESCRIPTION
This allows the package to call the `nmcli` util without passing a password as parameter, currently passing `None` would create the following command

`sudo nmcli (--wait)? device wifi connect <SSID> password`

which is an invalid command as it is missing the password argument, with this change the command will be

`sudo nmcli (--wait)? device wifi connect <SSID>`

allowing connection with open networks and networks already known by `nmcli`

After the changes we would be opening the door to connect to OPEN networks and also to networks already known by `nmcli` without the need of passing it's password again.